### PR TITLE
retirando borda e adicionando imagem de fundo

### DIFF
--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -115,8 +115,7 @@ sy-script-tree .ng-star-inserted {
 }
 
 .ace_indent-guide {
-    background: none !important;
-    border-right: 1px solid var(--editor-indent-guide) !important;
+    background: url('https://mpce-dev.sydle.one/api/1/main/_ecm/_defaultFile/www/Utilitarios/imagem de fundo do cursor versão tema one dark.png/') right repeat-y !important;
 }
 
 .ace_keyword {


### PR DESCRIPTION
Foi realizado o upload de uma imagem parecida à usada como fundo para indentação pelo SYDLE, na qual não são adicionadas bordas, o que estava causando impacto na posição do cursor ao usar o TAB para espaçar o código.